### PR TITLE
Install lodash and pluralize for schema generation improvements

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -11,6 +11,8 @@
     "@std/fs": "jsr:@std/fs@^0.218.2",
     "@std/path": "jsr:@std/path@^1.0.8",
     "@/": "./",
-    "@/generators/": "./generators/"
+    "@/generators/": "./generators/",
+    "lodash": "npm:lodash@^4.17.21",
+    "pluralize": "jsr:@wei/pluralize@^8.0.2"
   }
 }

--- a/generators/schema.ts
+++ b/generators/schema.ts
@@ -1,8 +1,8 @@
-// lib/generators/schema.ts
-
 import { Config } from '@/config.ts';
+import _ from 'lodash';
 import { ensureDir } from '@std/fs';
 import { join } from '@std/path';
+import pluralize from 'pluralize';
 
 export async function generateSchema(
   config: Config,
@@ -10,19 +10,35 @@ export async function generateSchema(
 ): Promise<void> {
   const schemaDir = config.schemaDir;
   await ensureDir(schemaDir);
+  const pluralName = pluralize(tableName.toLowerCase());
+  const singluarName = pluralize.singular(pluralName);
 
-  const fileName = `${tableName.toLowerCase()}.ts`;
+  const fileName = `${_.kebabCase(pluralName)}.ts`;
   const filePath = join(schemaDir, fileName);
 
   const schemaContent = `
-import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { boolean, index, integer, pgTable, relations, text, timestamp } from "drizzle-orm/pg-core";
 
-export const ${tableName} = sqliteTable('${tableName}', {
-  id: integer('id').primaryKey(),
-  name: text('name').notNull(),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().defaultNow(),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().defaultNow(),
-});
+export const ${pluralName}Table = pgTable(
+  '${pluralName}',
+  {
+    id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+    name: text('name'),
+    isActive: boolean('is_active').defaultTo(true),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => ({
+    nameIdx: index('${pluralName}_name_idx').using('btree', table.name),
+  }),
+);
+
+export const ${singluarName}Relations = relations(${pluralName}Table, () => ({}));
 `;
 
   await Deno.writeTextFile(filePath, schemaContent);


### PR DESCRIPTION
Integrate lodash and pluralize libraries to enhance schema generation functionality, addressing HACK-6. This allows for better handling of table names and schema definitions.