### PR TITLE
Add type definition generator and standardize name formats utility

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -6,6 +6,7 @@ import { generateSchema, updateSchemaIndex } from '@/generators/schema.ts';
 import { Command } from '@cliffy/command';
 import { ensureDir } from '@std/fs';
 import { generateColumnHelpers } from '@/generators/column.helpers.ts';
+import { generateTypeDefinitions } from '@/generators/type-defintions.ts';
 import { generateValidators } from '@/generators/validators.ts';
 
 const cli = new Command()
@@ -22,6 +23,7 @@ cli
     await generateSchema(config, tableName);
     await updateSchemaIndex(config, tableName);
     await generateValidators(config, tableName);
+    await generateTypeDefinitions(config, tableName);
     console.log('Schema generation complete.');
   });
 

--- a/generators/column.helpers.ts
+++ b/generators/column.helpers.ts
@@ -1,5 +1,4 @@
 import { Config } from '@/config.ts';
-import _ from 'lodash';
 import { ensureDir } from '@std/fs';
 import { formatFile } from '@/utils.ts';
 import { join } from '@std/path';

--- a/generators/type-defintions.ts
+++ b/generators/type-defintions.ts
@@ -1,31 +1,28 @@
+import { formatFile, standardizeName } from '@/utils.ts';
+
 import { Config } from '@/config.ts';
-import _ from 'lodash';
 import { ensureDir } from '@std/fs';
-import { formatFile } from '@/utils.ts';
 import { join } from '@std/path';
-import pluralize from 'pluralize';
 
 export async function generateTypeDefinitions(
   config: Config,
   tableName: string
 ): Promise<void> {
-  const pluralName = pluralize(tableName.toLowerCase());
+  const names = standardizeName(tableName);
 
   // model resource directory should be something like lib/resources/users
-  const resourceDir = `${config.resourcesDir}/${pluralName}`;
+  const resourceDir = `${config.resourcesDir}/${names.kebabCase}`;
   await ensureDir(resourceDir);
-
-  const singluarName = _.startCase(pluralize.singular(pluralName));
 
   const fileName = `types.ts`;
   const filePath = join(resourceDir, fileName);
 
   const typeDefinitionContent = `
-    import { ${pluralName}Table } from '@/${config.schemaDir}';
+    import { ${names.camelCase}Table } from '@/${config.schemaDir}';
     import { z } from 'zod';
 
-    export type ${singluarName}Type = typeof ${pluralName}Table.$inferSelect;
-    export type ${singluarName}Input = typeof ${pluralName}Table.$inferInsert;
+    export type ${names.singularPascalCase}Type = typeof ${names.camelCase}Table.$inferSelect;
+    export type ${names.singularPascalCase}Input = typeof ${names.camelCase}Table.$inferInsert;
   `;
 
   await Deno.writeTextFile(filePath, typeDefinitionContent);

--- a/generators/type-defintions.ts
+++ b/generators/type-defintions.ts
@@ -1,0 +1,36 @@
+import { Config } from '@/config.ts';
+import _ from 'lodash';
+import { ensureDir } from '@std/fs';
+import { formatFile } from '@/utils.ts';
+import { join } from '@std/path';
+import pluralize from 'pluralize';
+
+export async function generateTypeDefinitions(
+  config: Config,
+  tableName: string
+): Promise<void> {
+  const pluralName = pluralize(tableName.toLowerCase());
+
+  // model resource directory should be something like lib/resources/users
+  const resourceDir = `${config.resourcesDir}/${pluralName}`;
+  await ensureDir(resourceDir);
+
+  const singluarName = _.startCase(pluralize.singular(pluralName));
+
+  const fileName = `types.ts`;
+  const filePath = join(resourceDir, fileName);
+
+  const typeDefinitionContent = `
+    import { ${pluralName}Table } from '@/${config.schemaDir}';
+    import { z } from 'zod';
+
+    export type ${singluarName}Type = typeof ${pluralName}Table.$inferSelect;
+    export type ${singluarName}Input = typeof ${pluralName}Table.$inferInsert;
+  `;
+
+  await Deno.writeTextFile(filePath, typeDefinitionContent);
+
+  await formatFile(filePath);
+
+  console.log(`Generated typeDefinition file: ${filePath}`);
+}

--- a/generators/validators.ts
+++ b/generators/validators.ts
@@ -1,21 +1,18 @@
+import { formatFile, standardizeName } from '@/utils.ts';
+
 import { Config } from '@/config.ts';
-import _ from 'lodash';
 import { ensureDir } from '@std/fs';
-import { formatFile } from '@/utils.ts';
 import { join } from '@std/path';
-import pluralize from 'pluralize';
 
 export async function generateValidators(
   config: Config,
   tableName: string
 ): Promise<void> {
-  const pluralName = pluralize(tableName.toLowerCase());
+  const names = standardizeName(tableName);
 
   // model resource directory should be something like lib/resources/users
-  const resourceDir = `${config.resourcesDir}/${pluralName}`;
+  const resourceDir = `${config.resourcesDir}/${names.kebabCase}`;
   await ensureDir(resourceDir);
-
-  const singluarName = _.startCase(pluralize.singular(pluralName));
 
   const fileName = `validators.ts`;
   const filePath = join(resourceDir, fileName);
@@ -25,22 +22,22 @@ export async function generateValidators(
 
   const validatorContent = `
     import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
-    import { ${pluralName}Table } from '@/${config.schemaDir}';
+    import { ${names.camelCase}Table } from '@/${config.schemaDir}';
     import { z } from 'zod';
 
-    export const delete${singluarName}Schema = z.object({
+    export const delete${names.singularPascalCase}Schema = z.object({
       id: ${idSchema},
     });
 
-    export const insert${singluarName}Schema = createInsertSchema(${pluralName}Table).omit({
+    export const insert${names.singularPascalCase}Schema = createInsertSchema(${names.camelCase}Table).omit({
       id: true,
       created: true,
       updated: true,
     });
 
-    export const select${singluarName}Schema = createSelectSchema(${pluralName}Table);
+    export const select${names.singularPascalCase}Schema = createSelectSchema(${names.camelCase}Table);
 
-    export const update${singluarName}Schema = createInsertSchema(${pluralName}Table).omit({
+    export const update${names.singularPascalCase}Schema = createInsertSchema(${names.camelCase}Table).omit({
       created: true,
       updated: true,
     });

--- a/utils.ts
+++ b/utils.ts
@@ -1,6 +1,54 @@
+import _ from 'lodash';
+import pluralize from 'pluralize';
+
 export async function formatFile(filePath: string): Promise<void> {
   const denoFmt = new Deno.Command('deno', {
     args: ['fmt', filePath],
   });
   await denoFmt.output();
+}
+
+/**
+ * Standardizes a table/model name for consistent naming across different inputs
+ * @param input - The original input name (can be camelCase, snake_case, with spaces, etc.)
+ * @returns An object with standardized naming conventions
+ */
+export function standardizeName(input: string) {
+  // Remove any special characters and replace with spaces
+  const cleanedInput = input.replace(/[^a-zA-Z0-9 ]/g, ' ');
+
+  // Convert to lowercase and trim
+  const normalizedInput = cleanedInput.toLowerCase().trim();
+
+  // Convert to singular form
+  const singularName = pluralize.singular(normalizedInput);
+
+  // Pluralize for table names
+  const pluralName = pluralize(singularName);
+
+  return {
+    // Camel case (e.g., featureFlag)
+    camelCase: _.camelCase(pluralName),
+
+    // Kebab case (e.g., feature-flags)
+    kebabCase: _.kebabCase(pluralName),
+
+    // Snake case (e.g., feature_flags)
+    snakeCase: _.snakeCase(pluralName),
+
+    // Pascal case for type names (e.g., FeatureFlags)
+    pascalCase: _.startCase(_.camelCase(pluralName)).replace(/ /g, ''),
+
+    // Singular version of the above (for single item references)
+    singularPascalCase: _.startCase(_.camelCase(singularName)).replace(
+      / /g,
+      ''
+    ),
+
+    // Original singular form
+    singular: singularName,
+
+    // Original plural form
+    plural: pluralName,
+  };
 }


### PR DESCRIPTION
Introduce a type definition generator to create TypeScript types based on schema tables and implement a utility function for standardizing naming formats across the application. This addresses HACK-3.